### PR TITLE
[251441] On Aqua, sub-tabs in Output tab have vertically off-center text and close buttons

### DIFF
--- a/core.windows/src/org/netbeans/core/windows/view/ui/CloseButtonTabbedPane.java
+++ b/core.windows/src/org/netbeans/core/windows/view/ui/CloseButtonTabbedPane.java
@@ -579,6 +579,11 @@ final class CloseButtonTabbedPane extends JTabbedPane implements PropertyChangeL
             };
             add(label);
             JButton tabCloseButton = CloseButtonFactory.createCloseButton();
+            if (IS_AQUA_LAF) {
+              // Bug #251441: Improve positioning of label and close button within the tab button.
+              setBorder(BorderFactory.createEmptyBorder(1, 0, 0, 0));
+              tabCloseButton.setBorder(BorderFactory.createEmptyBorder(2, 2, 0, 0));
+            }
             tabCloseButton.addActionListener(new ActionListener() {
 
                 @Override


### PR DESCRIPTION
Fix for the cosmetic issue described at https://netbeans.org/bugzilla/show_bug.cgi?id=251441 . (Patch also submitted on bugzilla, but I saw from the netbeans-incubator mailing list that you might be taking pull requests here.)

"On MacOS/Aqua, the text and close ("X") buttons of sub-tabs in the "Output" TopComponentm such as "Debugger Console" and "Run", are vertically off-center. I suggest pushing the text down 1 pixel and the "X" buttons down 2 pixels in such components."