### PR TITLE
[248664] HighlightingManager does not track changes to HighlightsLayerExcludes correctly.

### DIFF
--- a/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/HighlightingManager.java
+++ b/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/HighlightingManager.java
@@ -222,11 +222,15 @@ public final class HighlightingManager {
         public Highlighting(HighlightingManager manager, JTextComponent pane) {
             this.manager = manager;
             this.pane = pane;
-            this.paneFilter = new RegExpFilter(pane.getClientProperty(PROP_HL_INCLUDES), pane.getClientProperty(PROP_HL_EXCLUDES));
+            updatePaneFilter();
             this.pane.addPropertyChangeListener(WeakListeners.propertyChange(this, pane));
             rebuildAll();
         }
         
+        private void updatePaneFilter() {
+            paneFilter = new RegExpFilter(pane.getClientProperty(PROP_HL_INCLUDES), pane.getClientProperty(PROP_HL_EXCLUDES));
+        }
+
         synchronized HighlightsContainer bottomHighlights() {
             return bottomHighlights;
         }
@@ -266,6 +270,7 @@ public final class HighlightingManager {
 
         public @Override void propertyChange(PropertyChangeEvent evt) {
             if (evt.getPropertyName() == null || PROP_DOCUMENT.equals(evt.getPropertyName())) {
+                updatePaneFilter();
                 Document doc = pane.getDocument();
                 if (doc != null) {
                     doc.render(new Runnable() {
@@ -278,6 +283,7 @@ public final class HighlightingManager {
             }
 
             if (PROP_HL_INCLUDES.equals(evt.getPropertyName()) || PROP_HL_EXCLUDES.equals(evt.getPropertyName())) {
+                updatePaneFilter();
                 rebuildAllLayers();
             }
         }


### PR DESCRIPTION
Fix for the bug described at https://netbeans.org/bugzilla/show_bug.cgi?id=248664 . (Patch also submitted on bugzilla, but I saw from the netbeans-incubator mailing list that you might be taking pull requests here.)

"The editor API defines the JEditorPane client properties HighlightsLayerExcludes and HighlightsLayerIncludes [1] to allow clients to show/hide specific highlight layers on demand. The bug is that modifications to these properties are not reflected properly in the editor."

This bug does not affect the IDE as far as I know, but affects my NetBeans Platform application. My platform application features a spreadsheet-like "formula bar" that uses the NetBeans editor infrastructure to provide syntax highlighting. The use case is to be able to deactivate the highlighting (specifically, brace matching) when the component is not focused. This requires the HighlightingManager to properly respond to changes in the HighlightsLayerExcludes/HighlightsLayerIncludes properties.