### PR TITLE
[269451] Scroll position flips back on scrolling with mouse wheel.

### DIFF
--- a/editor.lib2/src/org/netbeans/api/editor/caret/EditorCaret.java
+++ b/editor.lib2/src/org/netbeans/api/editor/caret/EditorCaret.java
@@ -1648,7 +1648,14 @@ public final class EditorCaret implements Caret {
                                 caretFoldExpander.checkExpandFolds(c, expandFoldPositions);
                             }
                         }
-                        if (activeTransaction.isDotOrStructuralChange()) {
+                        /* 269451: If we set scrollToLastCaret above, we need to let dispatchUpdate
+                                   happen so the former can be cleared again. A comment in
+                                   CaretTransaction suggests that scrolling really should happen
+                                   even if the dot offset is not changed. ("Scroll even if setDot()
+                                   to same offset"). */
+                        if (activeTransaction.isDotOrStructuralChange() ||
+                            activeTransaction.isScrollToLastCaret())
+                        {
                             if (!inAtomicSectionL) {
                                 // For now clear the lists and use old way TODO update to selective updating and rendering
                                 fireStateChanged(activeTransaction.getOrigin());


### PR DESCRIPTION
Fix for the bug described at https://netbeans.org/bugzilla/show_bug.cgi?id=269451 . (Patch also submitted on bugzilla, but I saw from the netbeans-incubator mailing list that you might be taking pull requests here.)

Summary: When the user clicks somewhere in the Java editor to place the caret, and then scrolls away, the scroll viewport may suddenly jump back to the cursor some time later.
